### PR TITLE
Basic support for queries as POST requests

### DIFF
--- a/src/express/index.js
+++ b/src/express/index.js
@@ -1,6 +1,7 @@
 var checkDep = require('../util').checkDep;
 var isPrefixed = require('../util').isPrefixed;
 var isGet = require('../util').isGet;
+var isPost = require('../util').isPost;
 
 function create() {
   return function(options) {
@@ -13,9 +14,16 @@ function create() {
 
     return function(request, respone, next) {
 
-      var query = request.query.q;
+      var query;
+      if (isGet(request)) {
+        query = request.query.q;
+      } else if (isPost(request)) {
+        query = request.body.query;
+      } else {
+        return next();
+      }
 
-      if (isGet(request) && isPrefixed(request, prefix)) {
+      if (isPrefixed(request, prefix)) {
         return adapter.graphql(schema, query)
           .then(function(result) {
             respone.json(result);

--- a/src/express/index.spec.js
+++ b/src/express/index.spec.js
@@ -59,7 +59,7 @@ describe('graffiti express', function() {
 
   describe('requested url starts with prefix', function() {
 
-    it('returns with proper results', function() {
+    describe('returns with proper results', function() {
 
       var result = {
         data: 1
@@ -78,21 +78,44 @@ describe('graffiti express', function() {
         }
       });
 
-      var request = {
-        method: 'GET',
-        path: '/graphql',
-        query: {
-          q: '{__type}'
-        }
-      };
+      it('as a GET request', function() {
 
-      var response = {
-        json: function(d) {
-          expect(d).to.eql(result);
-        }
-      };
+        var request = {
+          method: 'GET',
+          path: '/graphql',
+          query: {
+            q: '{__type}'
+          }
+        };
 
-      mw(request, response);
+        var response = {
+          json: function(d) {
+            expect(d).to.eql(result);
+          }
+        };
+
+        mw(request, response);
+      });
+
+      it('as a POST request', function() {
+
+        var request = {
+          method: 'POST',
+          path: '/graphql',
+          body: {
+            query: '{__type}'
+          }
+        };
+
+        var response = {
+          json: function(d) {
+            expect(d).to.eql(result);
+          }
+        };
+
+        mw(request, response);
+      });
+
     });
 
   });

--- a/src/hapi/index.js
+++ b/src/hapi/index.js
@@ -14,7 +14,6 @@ function create() {
         method: 'GET',
         path: '/',
         handler: function(request, reply) {
-
           var query = request.query.q;
 
           return adapter.graphql(schema, query)

--- a/src/hapi/index.spec.js
+++ b/src/hapi/index.spec.js
@@ -26,7 +26,7 @@ describe('graffiti hapi', function() {
 
   });
 
-  describe('returns with proper results', function(done) {
+  it('returns with proper results', function(done) {
 
     var server = new Hapi.Server();
     server.connection({ port: 3000 });
@@ -42,7 +42,7 @@ describe('graffiti hapi', function() {
         adapter: {
           getSchema: function() {},
           graphql: function() {
-            return Promise.resolve();
+            return Promise.resolve(result);
           }
         }
       }

--- a/src/koa/index.js
+++ b/src/koa/index.js
@@ -1,6 +1,7 @@
 var checkDep = require('../util').checkDep;
 var isPrefixed = require('../util').isPrefixed;
 var isGet = require('../util').isGet;
+var isPost = require('../util').isPost;
 
 function create() {
   return function koa(options) {
@@ -13,9 +14,16 @@ function create() {
 
     return function *(next) {
 
-      var query = this.query.q;
+      var query;
+      if (isGet(this)) {
+        query = this.query.q;
+      } else if (isPost(this)) {
+        query = this.body.query;
+      } else {
+        return next();
+      }
 
-      if (isGet(this) && isPrefixed(this, prefix)) {
+      if (isPrefixed(this, prefix)) {
         this.body = yield adapter.graphql(schema, query);
         return this.body;
       }

--- a/src/koa/index.spec.js
+++ b/src/koa/index.spec.js
@@ -45,7 +45,7 @@ describe('graffiti koa', function() {
 
   describe('requested url starts with prefix', function() {
 
-    it('returns with proper results', function *() {
+    describe('returns with proper results', function() {
 
       var result = {
         data: 1
@@ -66,17 +66,38 @@ describe('graffiti koa', function() {
         }
       });
 
-      var request = {
-        method: 'GET',
-        path: '/graphql',
-        query: {
-          q: '{__type}'
-        }
-      };
+      it('as a GET request', function *() {
 
-      var res = yield mw.call(request);
+        var request = {
+          method: 'GET',
+          path: '/graphql',
+          query: {
+            q: '{__type}'
+          }
+        };
 
-      expect(res).to.eql(result);
+        var res = yield mw.call(request);
+
+        expect(res).to.eql(result);
+
+      });
+
+      it('as a POST request', function *() {
+
+        var request = {
+          method: 'POST',
+          path: '/graphql',
+          body: {
+            query: '{__type}'
+          }
+        };
+
+        var res = yield mw.call(request);
+
+        expect(res).to.eql(result);
+
+      });
+
     });
 
   });

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -2,6 +2,10 @@ function isGet(request) {
   return request.method === 'GET';
 }
 
+function isPost(request) {
+  return request.method === 'POST';
+}
+
 function isPrefixed(request, prefix) {
   return request.path.indexOf(prefix) === 0;
 }
@@ -20,4 +24,5 @@ function checkDep(obj, propName) {
 
 module.exports.checkDep = checkDep;
 module.exports.isGet = isGet;
+module.exports.isPost = isPost;
 module.exports.isPrefixed = isPrefixed;

--- a/src/util/index.spec.js
+++ b/src/util/index.spec.js
@@ -20,6 +20,14 @@ describe('graffiti util', function() {
 
   });
 
+  describe('#isPost', function() {
+
+    it('returns true for POST');
+
+    it('returns false for not POSTs');
+
+  });
+
   describe('#checkDep', function() {
 
     it('throws if first argument is undefined', function() {


### PR DESCRIPTION
parse out the `query` key of a POST request arriving at the graphQL endpoint