### PR TITLE
Add CSRF token to GraphiQL view

### DIFF
--- a/src/express/express.js
+++ b/src/express/express.js
@@ -16,14 +16,18 @@ function sendError(response, boom) {
   response.status(statusCode).send(payload);
 }
 
-export default function middleware({ graphiql = true, context = {}, schema = required() } = {}) {
+export default function middleware({ graphiql = true, context = {}, schema = required(), getCSRFToken = null } = {}) {
   return (request, response, next) => {
     if (isPath(request) && (isPost(request) || isGet(request))) {
       const body = request.body;
       const { query, variables } = Object.assign({}, body, request.query);
 
       if (isGet(request) && request.accepts('html') && graphiql) {
-        return response.send(renderGraphiQL({ query, variables }));
+        const renderOptions = { query, variables };
+        if (getCSRFToken !== null) {
+          renderOptions.csrfToken = getCSRFToken(request);
+        }
+        return response.send(renderGraphiQL(renderOptions));
       }
 
       if (isGet(request) && query && query.includes('mutation')) {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -16,7 +16,8 @@ export function required() {
 
 const GRAPHIQL_VERSION = '0.7.1';
 
-export function renderGraphiQL({ query, variables, version = GRAPHIQL_VERSION } = {}) {
+export function renderGraphiQL({ query, variables, version = GRAPHIQL_VERSION, csrfToken } = {}) {
+  csrfToken = csrfToken ? `,'x-csrf-token': '${csrfToken}'` : '';
   return `
     <!DOCTYPE html>
     <html>
@@ -89,7 +90,8 @@ export function renderGraphiQL({ query, variables, version = GRAPHIQL_VERSION } 
               method: 'post',
               headers: {
                 'Accept': 'application/json',
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json'
+                ${csrfToken}
               },
               body: JSON.stringify(graphQLParams),
               credentials: 'include',


### PR DESCRIPTION
This change adds a `getCSRFToken` method that if provided can be invoked with the `request` to get a CSRF token for example:  `req.csrfToken()`.

This is needed for securing the GraphiQL views (especially on production instances!). I'm using a modified version of this in development to allow my csrf strategy to work. Let me know what you think!
