### PR TITLE
Do not hardcode /graphql endpoint

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -85,7 +85,7 @@ export function renderGraphiQL({ query, variables, version = GRAPHIQL_VERSION } 
           }
           // Defines a GraphQL fetcher using the fetch API.
           function graphQLFetcher(graphQLParams) {
-            return fetch(window.location.origin + '/graphql', {
+            return fetch(window.location.origin + window.location.pathname, {
               method: 'post',
               headers: {
                 'Accept': 'application/json',


### PR DESCRIPTION
This is a trivial change that un-hardcodes the `/graphql` endpoint for the API. Things should still work as they were, but now we can also use the UI under any other URL it has been deployed to :) 