### PR TITLE
feat(util): use relative url instead of hardcoded

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -85,7 +85,7 @@ export function renderGraphiQL({ query, variables, version = GRAPHIQL_VERSION } 
           }
           // Defines a GraphQL fetcher using the fetch API.
           function graphQLFetcher(graphQLParams) {
-            return fetch(window.location.origin + '/graphql', {
+            return fetch(window.location.href, {
               method: 'post',
               headers: {
                 'Accept': 'application/json',


### PR DESCRIPTION
Make this plugin compatible with all sorts of URL rewrites.

graffiti currently expects a `/graphql` endpoint absolute to the current URL.
This patch fixes that, so that graffiti can be used with spooky URL rewrites.
This also theoretically enables to rename `/graphql` without breaking graphiql (I think)